### PR TITLE
Fix Vector2.Rotate to use stored values

### DIFF
--- a/World/Engine/Primitives/Vector2.cs
+++ b/World/Engine/Primitives/Vector2.cs
@@ -53,11 +53,16 @@ public class Vector2
 
         var (sin, cos) = Math.SinCos(angleRad);
 
-        X1 = (float)((X1 - x) * cos - (Y1 - x) * sin + x);
-        Y1 = (float)((X1 - y) * sin + (Y1 - y) * cos + y);
+        var oldX1 = X1;
+        var oldY1 = Y1;
+        var oldX2 = X2;
+        var oldY2 = Y2;
 
-        X2 = (float)((X2-x) * cos - (Y2-x) * sin + x);
-        Y2 = (float)((X2-y) * sin + (Y2-y) * cos + y);
+        X1 = (float)((oldX1 - x) * cos - (oldY1 - y) * sin + x);
+        Y1 = (float)((oldX1 - x) * sin + (oldY1 - y) * cos + y);
+
+        X2 = (float)((oldX2 - x) * cos - (oldY2 - y) * sin + x);
+        Y2 = (float)((oldX2 - x) * sin + (oldY2 - y) * cos + y);
     }
 
     public static Vector2 Empty()


### PR DESCRIPTION
## Summary
- correct Vector2.Rotate rotation logic by using old coordinate values
- ensure proper subtraction of `y` value when rotating

## Testing
- `dotnet build World.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f931f61208323be8d6c4f1e11ad67